### PR TITLE
Catch unicode hex error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 
 [dependencies]

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -48,6 +48,9 @@ pub fn to_hex_multiple(bytearray: &[Vec<u8>]) -> Vec<String> {
 /// Decode a hex string into bytes.
 pub fn from_hex(hex_str: &str) -> Result<Vec<u8>, HexError> {
     let hex_trim = hex_str.trim();
+    if !hex_str.is_ascii() {
+        return Err(HexError::HexConversionError);
+    }
     let hex_trim = if (hex_trim.len() >= 2) && (&hex_trim[..2] == "0x") {
         &hex_trim[2..]
     } else {
@@ -96,6 +99,8 @@ mod test {
         assert_eq!(from_hex(&"0x800000ff").unwrap(), vec![128, 0, 0, 255]);
         assert!(from_hex(&"800").is_err()); // Odd number of bytes
         assert!(from_hex(&"8080gf").is_err()); // Invalid hex character g
+                                               // unicode strings have odd lengths and can cause panics
+        assert!(from_hex("🖖🥴").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Many unicode characters are more than 1 byte long (e.g. emoji). If one
tries to take a slice on a string containing such characters that
would otherwise 'break' the character, a panic is thrown.

The `from_hex` function had a bug that checked if the first 2 cahrs of a
string are '0x' when converting from string to a byte string. Passing an
emoji to this function would cause a panic.

Since any non-ascii characters aren't valid hexadecimal anyway, we can
check that all characters are actually ascii before doing any slice
checks.

A test was added that catches this case and confirms that the bug is
fixed.