### PR TITLE
Refactor Hex to remove associated type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 
 [dependencies]

--- a/src/byte_array.rs
+++ b/src/byte_array.rs
@@ -89,9 +89,7 @@ impl ByteArray for [u8; 32] {
 }
 
 impl<T: ByteArray> Hex for T {
-    type T = T;
-
-    fn from_hex(hex: &str) -> Result<Self::T, HexError> {
+    fn from_hex(hex: &str) -> Result<Self, HexError> {
         let v = from_hex(hex)?;
         Self::from_vec(&v).map_err(|_| HexError::HexConversionError)
     }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -7,10 +7,10 @@ use thiserror::Error;
 
 /// Any object implementing this trait has the ability to represent itself as a hexadecimal string and convert from it.
 pub trait Hex {
-    type T;
-    /// Try and convert the given hexadecimal string to the type. Any failures (incorrect  string length, non hex
+    /// Try to convert the given hexadecimal string to the type. Any failures (incorrect  string length, non hex
     /// characters, etc) return a [KeyError](enum.KeyError.html) with an explanatory note.
-    fn from_hex(hex: &str) -> Result<Self::T, HexError>;
+    fn from_hex(hex: &str) -> Result<Self, HexError>
+    where Self: Sized;
 
     /// Return the hexadecimal string representation of the type
     fn to_hex(&self) -> String;


### PR DESCRIPTION
There's no need for an associated type in the hex trait; the
`from_hex` method should just return `Self`