### PR TITLE
Removed unnecessary heap allocation in Hex::to_hex

### DIFF
--- a/src/byte_array.rs
+++ b/src/byte_array.rs
@@ -91,10 +91,10 @@ impl ByteArray for [u8; 32] {
 impl<T: ByteArray> Hex for T {
     fn from_hex(hex: &str) -> Result<Self, HexError> {
         let v = from_hex(hex)?;
-        Self::from_vec(&v).map_err(|_| HexError::HexConversionError)
+        Self::from_bytes(&v).map_err(|_| HexError::HexConversionError)
     }
 
     fn to_hex(&self) -> String {
-        to_hex(&self.to_vec())
+        to_hex(self.as_bytes())
     }
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -29,7 +29,7 @@ pub enum HexError {
 /// Encode the provided bytes into a hex string
 pub fn to_hex<T>(bytes: &[T]) -> String
 where T: LowerHex {
-    let mut s = String::new();
+    let mut s = String::with_capacity(bytes.len() * 2);
     for byte in bytes {
         write!(&mut s, "{:02x}", byte).expect("Unable to write");
     }


### PR DESCRIPTION
`Hex::to_hex` now converts the given byte slice to hex directly instead
of converting a copy of the data (allocated on the heap).

`to_hex` now reserves the required memory for the string once
potentially saving on additional allocations.