### PR TITLE
Add checked_uint_to_bits, remove uint_to_bits

### DIFF
--- a/src/bit.rs
+++ b/src/bit.rs
@@ -45,25 +45,6 @@ pub fn checked_uint_to_bits(value: usize, bit_count: usize) -> Option<Vec<bool>>
     Some(bits)
 }
 
-/// Converts a single input integer to a vector of bits (little-endian)
-///
-/// ## Panics
-///
-/// This function will panic if `bit_count` is set higher than the number of bits in usize (typically, 32 or 64).
-#[deprecated(
-    since = "0.3.1",
-    note = "uint_to_bits is deprecated, use checked_uint_to_bits instead"
-)]
-pub fn uint_to_bits(value: usize, bit_count: usize) -> Vec<bool> {
-    assert!(
-        bit_count < mem::size_of::<usize>() * 8,
-        "bit_count must be less than or equal to the number of bits in usize ({})",
-        mem::size_of::<usize>() * 8
-    );
-
-    checked_uint_to_bits(value, bit_count).unwrap()
-}
-
 /// Converts a array of input bits (little-endian) to a single byte
 pub fn bits_to_byte(bits: [bool; 8]) -> u8 {
     let mut value: u8 = 0;


### PR DESCRIPTION
- Adds checked_uint_to_bits, that returns None if the bit_count > 32 or
  64 (depending on architecture). This prevents an overflow on the
  shift-left operation and allows the caller to decide on how they want to deal with it.
- ~~Deprecates~~ removes uint_to_bits (breaking change).
- ~~uint_to_bits panics if the bit_count is large in release mode~~
  (previously only debug)
- Added basic tests

Tari usage: this function is only used with bit_count 11, so in this case it can safely use unwrap on the checked version

Issue found by @the-mog
related code: https://github.com/tari-project/tari/blob/c58a7e53c409cd90ec319c70410aabd477f3f8ed/base_layer/mmr/src/common.rs#L36