### PR TITLE
[fuzzing] Change `bits_to_uint` to check for shift overflow

### DIFF
--- a/src/bit.rs
+++ b/src/bit.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 // Copyright 2019 The Tari Project
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
@@ -48,12 +50,20 @@ pub fn bits_to_byte(bits: [bool; 8]) -> u8 {
 }
 
 /// Converts a vector of input bits (little-endian) to its integer representation
-pub fn bits_to_uint(bits: &[bool]) -> usize {
-    let mut value: usize = 0;
-    for i in 0..bits.len() {
-        value |= (bits[i] as usize) << i;
+/// Returns None if the length of `bits` is greater than the number of bits in a `usize`, which would cause an attempt
+/// to shift left with overflow
+pub fn checked_bits_to_uint(bits: &[bool]) -> Option<usize> {
+    const PTR_SIZE_BITS: usize = mem::size_of::<usize>() * 8;
+
+    if bits.len() > PTR_SIZE_BITS {
+        None
+    } else {
+        let mut value: usize = 0;
+        for i in 0..bits.len() {
+            value |= (bits[i] as usize) << i;
+        }
+        Some(value)
     }
-    (value)
 }
 
 /// Converts a vector of input bytes to a vector of bits

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -19,3 +19,49 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::mem;
+use tari_utilities::bit::checked_bits_to_uint;
+
+#[test]
+fn shift_left_overflow_bits_to_uint() {
+    const PTR_SIZE_BITS: usize = mem::size_of::<usize>() * 8;
+
+    let bits = [true];
+    let result = checked_bits_to_uint(&bits);
+    assert_eq!(result, Some(1));
+
+    let bits = [false, true];
+    let result = checked_bits_to_uint(&bits);
+    assert_eq!(result, Some(2));
+
+    let bits = [true, true];
+    let result = checked_bits_to_uint(&bits);
+    assert_eq!(result, Some(3));
+
+    let bits = [false; PTR_SIZE_BITS];
+    let result = checked_bits_to_uint(&bits);
+    assert_eq!(result, Some(0));
+
+    // lengths greater than the machine ptr size (typically 64bit) would overflow
+    let bits = [false; PTR_SIZE_BITS + 1];
+    let result = checked_bits_to_uint(&bits);
+    assert_eq!(result, None);
+
+    let bits = [false; 128];
+    let result = checked_bits_to_uint(&bits);
+    assert_eq!(result, None);
+
+    let bits = [
+        false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+        false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+        false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+        false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+        false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+        false, false, false, true, false, false, false, false, false, false, false, false, false, false, false, false,
+        false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+        false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false,
+    ];
+    let result = checked_bits_to_uint(&bits);
+    assert_eq!(result, None);
+}


### PR DESCRIPTION
This PR changes the `bits_to_uint` function to check for attempt to shift with overflow. 

This is a breaking change and would require a new version of the crate published, and the related code updated in the Tari repo on upgrade. 

Added some test cases. Related to #9 - I think these 2 PRs should be merged and use the same approach, both should rename the functions and return options.

Issue details: 

A shift left overflow can be triggered inside the bits_to_uint function.
This overflow is triggering a panic if the code is compile in debug mode (overflow-checks compiler flag) and it will be completely silent if the code is compiled in release mode.

Details:

found by @pventuzelo
found using fuzzing
related code (bits_to_uint): https://github.com/tari-project/tari_utilities/blob/da015a3c5b0a003e6ae43a048b2260a7f63cc3b9/src/bit.rs#L51