### PR TITLE
feat: add time crate support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ rand = "0.7.2"
 newtype-ops = "0.1.4"
 bitflags = "1.2.1"
 base58-monero = {version = "0.2.0", default-features= false}
+time = "0.3.4"
 
 [dev-dependencies]


### PR DESCRIPTION
`chrono` crate uses `time` internally, but it's not actively maintained and we should prefer to use `time` crate directly.
There is at least one known security issue in `chrono`: https://github.com/chronotope/chrono/issues/602