### PR TITLE
fix: avoid implicit time dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 thiserror = "1.0"
 clear_on_drop = "0.2.4"
-chrono = { version = "0.4.9", features = ["serde"]}
+chrono = { version = "0.4.9", default-features = false, features = ["serde"]}
 bincode = "1.1.4"
 base64 = "0.10.1"
 serde_json = "1.0"


### PR DESCRIPTION
This fix removes implicit usage of the outdated `time` (1.43.0) crate.