### PR TITLE
fix(byte_array): remove unnecessary allocation in to_hex

### DIFF
--- a/src/byte_array.rs
+++ b/src/byte_array.rs
@@ -95,6 +95,6 @@ impl<T: ByteArray> Hex for T {
     }
 
     fn to_hex(&self) -> String {
-        to_hex(&self.to_vec())
+        to_hex(self.as_bytes())
     }
 }


### PR DESCRIPTION
Removes an unnecessary heap allocation in to_hex
