### PR TITLE
feat: hidden type to mask sensitive data in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ Macros for RwLock.
 
 A `MessageFormat` trait that handles conversion from and to binary, json, or base64.
 
+## Hidden
+
+A wrapper type for concealing sensitive information in logs.

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -1,13 +1,39 @@
+// Copyright 2020. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! A wrapper to conceal secrets when output into logs or displayed.
+
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::DerefMut;
 
+/// A simple struct with a single inner value to wrap content of any type.
 #[derive(Copy, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Hidden<T> {
     inner: T,
 }
 
+/// Returns ownership of the inner value discarding the wrapper.
 impl<T> Hidden<T> {
     pub fn into_inner(self) -> T {
         self.inner
@@ -20,18 +46,21 @@ impl<T> From<T> for Hidden<T> {
     }
 }
 
+/// Defines a masked value for the type to output as debug information. Concealing the secrets within.
 impl<T> fmt::Debug for Hidden<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Hidden<{}>", std::any::type_name::<T>())
     }
 }
 
+/// Defines a masked value for the type to display. Concealing the secrets within.
 impl<T> fmt::Display for Hidden<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Hidden<{}>", std::any::type_name::<T>())
     }
 }
 
+/// Attempts to make the wrapper more transparent by having deref return a reference to the inner value.
 impl<T> std::ops::Deref for Hidden<T> {
     type Target = T;
 

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -3,6 +3,7 @@ use std::ops::DerefMut;
 use serde::{Serialize, Deserialize};
 
 #[derive(Copy, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Hidden<T> {
     inner: T,
 }
@@ -45,7 +46,7 @@ impl<T> DerefMut for Hidden<T> {
     }
 }
 
-impl<T: std::cmp::PartialEq> PartialEq for Hidden<T> {
+impl<T: PartialEq> PartialEq for Hidden<T> {
     fn eq(&self, other: &Self) -> bool {
         self.inner == other.inner
     }

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -1,6 +1,6 @@
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::DerefMut;
-use serde::{Serialize, Deserialize};
 
 #[derive(Copy, Clone, Serialize, Deserialize)]
 #[serde(transparent)]

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -22,9 +22,9 @@
 
 //! A wrapper to conceal secrets when output into logs or displayed.
 
+use std::{fmt, ops::DerefMut};
+
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::ops::DerefMut;
 
 /// A simple struct with a single inner value to wrap content of any type.
 #[derive(Copy, Clone, Serialize, Deserialize)]

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -1,0 +1,63 @@
+use std::fmt;
+use std::ops::DerefMut;
+use serde::{Serialize, Deserialize};
+
+#[derive(Copy, Clone, Serialize, Deserialize)]
+pub struct Hidden<T> {
+    inner: T,
+}
+
+impl<T> Hidden<T> {
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T> From<T> for Hidden<T> {
+    fn from(inner: T) -> Self {
+        Hidden { inner }
+    }
+}
+
+impl<T> fmt::Debug for Hidden<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Hidden<{}>", std::any::type_name::<T>())
+    }
+}
+
+impl<T> fmt::Display for Hidden<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Hidden<{}>", std::any::type_name::<T>())
+    }
+}
+
+impl<T> std::ops::Deref for Hidden<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> DerefMut for Hidden<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T: std::cmp::PartialEq> PartialEq for Hidden<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn into_applies_wrapper_deref_removes_it() {
+        let wrapped: Hidden<u8> = 42.into();
+        assert_eq!(42, *wrapped)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,8 +32,10 @@ pub mod hex;
 #[macro_use]
 pub mod locks;
 pub mod message_format;
+pub mod hidden;
 
 pub use self::{
     byte_array::{ByteArray, ByteArrayError},
     hash::Hashable,
+    hidden::Hidden,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@ pub mod hash;
 pub mod hex;
 #[macro_use]
 pub mod locks;
-pub mod message_format;
 pub mod hidden;
+pub mod message_format;
 
 pub use self::{
     byte_array::{ByteArray, ByteArrayError},


### PR DESCRIPTION
Description
---
Adding a wrapper type to mask sensitive data in debug, and log output.

Motivation and Context
---
To reduce attack vector surface area by ensuring log data doesn't contain private information.

How Has This Been Tested?
---
With a single test. It has not yet been applied in practice.