### PR TITLE
feat: prepare 0.4.4 to release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.4.4](https://github.com/tari-project/tari_utilities/compare/v0.4.3...v0.4.4) (2022-06-14)
+
+
+### Features
+
+* added `hex` module with a serializer and deserializer [94c1452](https://github.com/tari-project/tari_utilities/commit/94c1452c64bebc74733c43c92cd9b4fb3651ab02)
+* `ByteArray` trait is implemented for byte arrays of all sizes [7f424dd](https://github.com/tari-project/tari_utilities/commit/7f424ddbc234b62f1564cc91e79692a095d32463)
+* added `Hidden` wrapper [f1010ba](https://github.com/tari-project/tari_utilities/commit/f1010bab437c74941d0680b21d6f95fd9d10cc8c)
+
 ### [0.4.3](https://github.com/tari-project/tari_utilities/compare/v0.4.2...v0.4.3) (2022-04-29)
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,15 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2018"
 
 [dependencies]
-base58-monero = {version = "0.3.2", default-features = false}
+base58-monero = { version = "0.3.2", default-features = false }
 base64 = "0.13.0"
 bincode = "1.3.3"
 newtype-ops = "0.1.4"
-serde = {version = "1.0.0", features = ["derive"] }
+serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
 thiserror = "1.0.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,6 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#![deny(missing_docs)]
-
 //! A set of useful and commonly used utilities that are used in several places in the Tari project.
 pub mod bit;
 pub mod byte_array;


### PR DESCRIPTION
The release notes added to the `CHANGELOG.md`.

Other changes:
- `#![deny(missing_docs)]` attribute removed, because it exists in the `lints.toml` file;
- `Cargo.toml` was updated and cleaned up