### PR TITLE
feat: add SafePassword struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ newtype-ops = "0.1.4"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
 thiserror = "1.0.0"
+zeroize = "1.4.0"
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/deny.toml
+++ b/deny.toml
@@ -74,6 +74,7 @@ allow = [
     "Apache-2.0",
     # "Apache-2.0 WITH LLVM-exception",
     "BSD-3-Clause",
+    "Unicode-DFS-2016",
     "WTFPL"
 ]
 # List of explicitly disallowed licenses

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -81,6 +81,8 @@ impl<T: PartialEq> PartialEq for Hidden<T> {
     }
 }
 
+impl<T: Eq> Eq for Hidden<T> {}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,10 +33,12 @@ pub mod hex;
 pub mod locks;
 pub mod hidden;
 pub mod message_format;
+pub mod password;
 pub mod serde;
 
 pub use self::{
     byte_array::{ByteArray, ByteArrayError},
     hash::Hashable,
     hidden::Hidden,
+    password::SafePassword,
 };

--- a/src/password.rs
+++ b/src/password.rs
@@ -1,3 +1,5 @@
+//! A module with a safe password wrapper.
+
 use std::{error::Error, fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};

--- a/src/password.rs
+++ b/src/password.rs
@@ -9,13 +9,13 @@ use crate::Hidden;
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct SafePassword {
-    password: Hidden<String>,
+    password: Hidden<Box<[u8]>>,
 }
 
 impl From<String> for SafePassword {
     fn from(s: String) -> Self {
         Self {
-            password: Hidden::from(s),
+            password: Hidden::from(s.into_bytes().into_boxed_slice()),
         }
     }
 }
@@ -42,15 +42,13 @@ impl FromStr for SafePassword {
     type Err = PasswordError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self {
-            password: Hidden::from(s.to_owned()),
-        })
+        Ok(Self::from(s.to_owned()))
     }
 }
 
 impl SafePassword {
     /// Gets a reference to bytes of a passphrase.
     pub fn reveal(&self) -> &[u8] {
-        self.password.as_bytes()
+        self.password.as_ref()
     }
 }

--- a/src/password.rs
+++ b/src/password.rs
@@ -1,0 +1,56 @@
+use std::{error::Error, fmt, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+use crate::Hidden;
+
+/// A hidden string that implements [`Zeroize`].
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct SafePassword {
+    password: Hidden<String>,
+}
+
+impl From<String> for SafePassword {
+    fn from(s: String) -> Self {
+        Self {
+            password: Hidden::from(s),
+        }
+    }
+}
+
+impl Drop for SafePassword {
+    fn drop(&mut self) {
+        self.password.zeroize();
+    }
+}
+
+/// An error for parsing a password from string.
+#[derive(Debug)]
+pub struct PasswordError;
+
+impl Error for PasswordError {}
+
+impl fmt::Display for PasswordError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PasswordError")
+    }
+}
+
+impl FromStr for SafePassword {
+    type Err = PasswordError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self {
+            password: Hidden::from(s.to_owned()),
+        })
+    }
+}
+
+impl SafePassword {
+    /// Gets a reference to bytes of a passphrase.
+    pub fn reveal(&self) -> &[u8] {
+        self.password.as_bytes()
+    }
+}

--- a/src/serde/hex.rs
+++ b/src/serde/hex.rs
@@ -120,7 +120,7 @@ mod tests {
         let hex_or_bytes = HexOrBytes([1, 2, 3, 255]);
         let expected = "\"010203ff\"";
         assert_eq!(serde_json::to_string(&hex_or_bytes).unwrap(), expected);
-        let restored: HexOrBytes = serde_json::from_str(&expected).unwrap();
+        let restored: HexOrBytes = serde_json::from_str(expected).unwrap();
         assert_eq!(hex_or_bytes, restored);
     }
 


### PR DESCRIPTION
The PR introduces a special wrapper for passphrases that guarantees the data will be erased when value dropped.

Notes:
- `unicode-ident` dependency adds extra `Unicode-DFS-2016` license since `1.0.2`: https://crates.io/crates/unicode-ident/versions
-  The license added to our list of allowed licenses (`deny.toml`), because `Unicode-DFS-2016` is approved by OSI: https://opensource.org/node/1077