### PR TITLE
feat!: update hashable to [u8;32]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.4.5"
+version = "0.5.0"
 edition = "2018"
 
 [dependencies]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -25,5 +25,5 @@
 /// Simple Hashable trait with single hash function.
 pub trait Hashable {
     /// Create a hash from this object
-    fn hash(&self) -> Vec<u8>;
+    fn hash(&self) -> [u8;32];
 }


### PR DESCRIPTION
We use the type `Fixedhash` in the Tari repo to represent a Hash. This used to be a `Vec<u8> `hence the `Hashable` trait returning a `Vec<u8>`. This is updating the trait to reflect the correct usage on the Tari side. 

Updates the version to 0.5 as this is a breaking change