### PR TITLE
feat: add reveal method to Hidden

### DIFF
--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -27,13 +27,17 @@ use std::{fmt, ops::DerefMut};
 use serde::{Deserialize, Serialize};
 
 /// A simple struct with a single inner value to wrap content of any type.
-#[derive(Copy, Clone, Serialize, Deserialize)]
+#[derive(Copy, Clone, Serialize, Deserialize, Default)]
 #[serde(transparent)]
 pub struct Hidden<T> {
     inner: T,
 }
 
 impl<T> Hidden<T> {
+    pub fn hide(inner: T) -> Self {
+        Self { inner }
+    }
+
     /// Returns ownership of the inner value discarding the wrapper.
     pub fn into_inner(self) -> T {
         self.inner
@@ -42,7 +46,7 @@ impl<T> Hidden<T> {
 
 impl<T> From<T> for Hidden<T> {
     fn from(inner: T) -> Self {
-        Hidden { inner }
+        Self::hide(inner)
     }
 }
 

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -22,18 +22,19 @@
 
 //! A wrapper to conceal secrets when output into logs or displayed.
 
-use std::{fmt, ops::DerefMut};
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
 /// A simple struct with a single inner value to wrap content of any type.
-#[derive(Copy, Clone, Serialize, Deserialize, Default)]
+#[derive(Copy, Clone, Serialize, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(transparent)]
 pub struct Hidden<T> {
     inner: T,
 }
 
 impl<T> Hidden<T> {
+    /// Hides a value.
     pub fn hide(inner: T) -> Self {
         Self { inner }
     }
@@ -41,6 +42,16 @@ impl<T> Hidden<T> {
     /// Returns ownership of the inner value discarding the wrapper.
     pub fn into_inner(self) -> T {
         self.inner
+    }
+
+    /// Provides access to the inner value (immutable).
+    pub fn reveal(&self) -> &T {
+        &self.inner
+    }
+
+    /// Provides access to the inner value (mutable).
+    pub fn reveal_mut(&mut self) -> &mut T {
+        &mut self.inner
     }
 }
 
@@ -64,36 +75,19 @@ impl<T> fmt::Display for Hidden<T> {
     }
 }
 
-/// Attempts to make the wrapper more transparent by having deref return a reference to the inner value.
-impl<T> std::ops::Deref for Hidden<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl<T> DerefMut for Hidden<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
-    }
-}
-
-impl<T: PartialEq> PartialEq for Hidden<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner
-    }
-}
-
-impl<T: Eq> Eq for Hidden<T> {}
-
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[test]
     fn into_applies_wrapper_deref_removes_it() {
-        let wrapped: Hidden<u8> = 42.into();
-        assert_eq!(42, *wrapped)
+        let wrapped: Hidden<u8> = Hidden::hide(42);
+        assert_eq!(42, *wrapped);
+    }
+
+    #[test]
+    fn hidden_value_derived_trats() {
+        let wrapped: Hidden<u8> = 0.into();
+        assert_eq!(wrapped, Hidden::default());
     }
 }

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -82,7 +82,7 @@ mod test {
     #[test]
     fn into_applies_wrapper_deref_removes_it() {
         let wrapped: Hidden<u8> = Hidden::hide(42);
-        assert_eq!(42, *wrapped);
+        assert_eq!(42, *wrapped.reveal());
     }
 
     #[test]

--- a/src/password.rs
+++ b/src/password.rs
@@ -24,7 +24,7 @@ impl<S: Into<String>> From<S> for SafePassword {
 
 impl Drop for SafePassword {
     fn drop(&mut self) {
-        self.password.zeroize();
+        self.password.reveal_mut().zeroize();
     }
 }
 
@@ -51,7 +51,7 @@ impl FromStr for SafePassword {
 impl SafePassword {
     /// Gets a reference to bytes of a passphrase.
     pub fn reveal(&self) -> &[u8] {
-        self.password.as_ref()
+        self.password.reveal()
     }
 }
 


### PR DESCRIPTION
# Description
Adds `reveal` method to make it clear what value used: hidden or inner.
Also other useful traits derived: `Default`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash`.

# Motivation and Context
Since `Hidden` implements `Deref` it's not clear to see where hidden or revealed value used (for `Display` trait, for example).
This change makes access to the hidden value explicit.

# How Has This Been Tested?
Unit tests
