### PR TITLE
feat: improve hidden data handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 base58-monero = { version = "0.3.2", default-features = false }
 base64 = "0.13.0"
 bincode = "1.3.3"
+generic-array = "0.14.6"
 newtype-ops = "0.1.4"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ bincode = "1.3.3"
 newtype-ops = "0.1.4"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
+subtle = "2.4.1"
 thiserror = "1.0.0"
 zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ newtype-ops = "0.1.4"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
 thiserror = "1.0.0"
-zeroize = "1.3.0"
+zeroize = { version = "1.3.0", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 rand = "0.7.0"

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -20,8 +20,11 @@
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-//! A generic type that hides data from being displayed or written, keeps it on the heap, zeroizes it when it goes away,
-//! limits access, and allows for type enforcement.
+//! Sometimes you need to handle sensitive data, like a passphrase or key material.
+//! There are pitfalls here that you want to avoid: the data should be zeroized when it goes out of scope, shouldn't be
+//! displayed or output to debug logs, shouldn't be unintentionally copied or moved, and often should have strict type
+//! differentiation to avoid it being misused in an unintended context. This library provides a generic type that can
+//! help.
 
 use std::{any::type_name, fmt, marker::PhantomData};
 
@@ -31,7 +34,24 @@ use zeroize::Zeroize;
 /// A marker trait for labeling different hidden types
 pub trait HiddenLabel {}
 
-/// Create a hidden type label
+/// This is a macro that produces a label for a hidden type.
+/// You can use it to generate multiple hidden types that can't be unintentionally mixed up in things like function
+/// definitions. You shouldn't ever need to access it directly once you define your hidden type, since it only exists to
+/// keep types in order.
+///
+/// Its use is optional; as shown elsewhere in this documentation, you can define a hidden type without the use of a
+/// label, in which a default one will be applied for you. But if you do that, you don't get the type enforcement
+/// benefits.
+///
+/// ```edition2018
+/// # #[macro_use] extern crate tari_utilities;
+/// # use tari_utilities::hidden::HiddenLabel;
+/// # use tari_utilities::hidden_label;
+/// # fn main() {
+/// // This makes `MyHiddenTypeLabel` available for later use when defining a hidden type
+/// hidden_label!(MyHiddenTypeLabel);
+/// # }
+/// ```
 #[macro_export]
 macro_rules! hidden_label {
     ($name:ident) => {
@@ -42,10 +62,95 @@ macro_rules! hidden_label {
     };
 }
 
-// A default hidden type label; only use this if you're absolutely sure you don't care about type enforcement
+// This is the hidden type label that is used internally if you define a hidden type without proving your own label
 hidden_label!(DefaultHiddenLabel);
 
-/// Data that needs to be kept hidden, needs to be zeroized when it goes away, and is resistant to misuse
+/// A generic type for data that needs to be kept hidden, needs to be zeroized when out of scope, and is resistant to
+/// misuse.
+///
+/// You can define a hidden type using any underlying type that supports `Default` and `Zeroize`.
+/// This is the case for most basic types that you probably care about.
+///
+/// You can optionally supply a label to the hidden type, which lets you define multiple hidden types that can't be
+/// interchanged. To do this, use the `hidden_label!` macro to define a label, and then use it when defining your hidden
+/// type. If you don't include a label, a default one is used for you.
+///
+/// Hidden data can't be copied, which is an intentional design decision, and you can only access it as a reference.
+/// However, it supports other functionality transparently: cloning, equality, ordering, serialization, and the like.
+/// Note an important fact about serialization: it's transparent, so the type label isn't serialized.
+/// This means you should be sure to know the label you intend during deserialization!
+///
+/// ```edition2018
+/// # use rand::rngs::OsRng;
+/// # use rand::RngCore;
+/// # use tari_utilities::hidden::{Hidden, HiddenLabel};
+/// # use tari_utilities::hidden_label;
+///
+/// // In this example, we need to handle keys for a cipher that are `[u8; 32]` byte arrays
+///
+/// // Define a label for the new hidden type
+/// // This ensures that any other `[u8; 32]` hidden types can't get confused with this one
+/// hidden_label!(CipherKeyLabel);
+///
+/// // Alias a new hidden type using the data type and label
+/// type CipherKey = Hidden<[u8; 32], CipherKeyLabel>;
+///
+/// // We can create hidden data from existing data; in this case, it's the caller's responsibility to make sure the existing data is handled securely
+/// let key_from_data = CipherKey::hide([1u8; 32]);
+///
+/// // We can access the hidden data as a reference, but not take ownership of it
+/// assert_eq!(key_from_data.reveal(), &[1u8; 32]);
+///
+/// // We can create default hidden data and then modify it as a mutable reference; this is common for functions that act on data in place
+/// let mut rng = OsRng;
+/// let mut key_in_place = CipherKey::default();
+/// rng.fill_bytes(key_in_place.reveal_mut());
+///
+/// // Cloning is safe to do
+/// let clone = key_in_place.clone();
+/// assert_eq!(key_in_place.reveal(), clone.reveal());
+/// ```
+///
+/// Type enforcement means the compiler won't let you mix and match hidden types with different labels.
+/// This can be important when dealing with different types of key material, for example.
+///
+/// ```compile_fail
+/// # use tari_utilities::hidden::{Hidden, HiddenLabel};
+/// # use tari_utilities::hidden_label;
+///
+/// // These are labels for different hidden types we want to create; in this case, keys for two different ciphers
+/// hidden_label!(KeyForCipherALabel);
+/// hidden_label!(KeyForCipherBLabel);
+///
+/// // Both ciphers have keys that are `[u8; 32]` under the hood
+/// type KeyForCipherA = Hidden<[u8; 32], KeyForCipherALabel);
+/// type KeyForCipherB = Hidden<[u8; 32], KeyForCipherBLabel);
+///
+/// // Create a key for each cipher; notice the underlying data is the same for both
+/// let key_a = KeyForCipherA::hide([1u8; 32]);
+/// let key_b = KeyForCipherA::hide([1u8; 32]);
+///
+/// // The compiler won't let us treat them the same; this won't build
+/// assert_eq!(key_a.reveal(), key_b.reveal());
+/// ```
+///
+/// But if you choose not to use a label, you can mix and match hidden types. Be careful if you do this!
+///
+/// ```edition2018
+/// # use tari_utilities::hidden::{Hidden, HiddenLabel};
+/// # use tari_utilities::hidden_label;
+///
+/// // Define two types with no labels; you probably don't want to actually do this!
+/// type TypeA = Hidden<[u8; 32]>;
+/// type TypeB = Hidden<[u8; 32]>;
+///
+/// // Create an instance of both
+/// let a = TypeA::default();
+/// let b = TypeB::default();
+///
+/// // You can mix and match these! Be sure that's what you actually intended.
+/// assert_eq!(a.reveal(), b.reveal());
+/// ```
 #[derive(Clone, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]
 pub struct Hidden<T, L = DefaultHiddenLabel>
@@ -63,7 +168,7 @@ where
     T: Zeroize,
     L: HiddenLabel,
 {
-    /// Hide the data
+    /// Create new hidden data from the underlying type
     pub fn hide(inner: T) -> Self {
         Self {
             inner: Box::new(inner),
@@ -82,7 +187,7 @@ where
     }
 }
 
-/// Only output masked data for debugging
+/// Only output masked data for debugging, keeping the hidden data hidden
 impl<T, L> fmt::Debug for Hidden<T, L>
 where
     T: Zeroize,
@@ -93,7 +198,7 @@ where
     }
 }
 
-/// Only display masked data
+/// Only display masked data, keeping the hidden data hidden
 impl<T, L> fmt::Display for Hidden<T, L>
 where
     T: Zeroize,
@@ -123,5 +228,44 @@ where
 {
     fn drop(&mut self) {
         self.zeroize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equality() {
+        assert_eq!(Hidden::<u8>::hide(0u8), Hidden::<u8>::hide(0u8));
+        assert_ne!(Hidden::<u8>::hide(0u8), Hidden::<u8>::hide(1u8));
+    }
+
+    #[test]
+    fn reference() {
+        assert_eq!(Hidden::<u8>::hide(0u8).reveal(), &0u8);
+        assert_ne!(Hidden::<u8>::hide(0u8).reveal(), &1u8);
+    }
+
+    #[test]
+    fn serialize() {
+        let hidden = Hidden::<u8>::hide(1u8);
+        let ser = serde_json::to_string(&hidden).unwrap();
+
+        let deser: Hidden<u8> = serde_json::from_str(&ser).unwrap();
+        assert_eq!(hidden, deser);
+
+        // You can deserialize with any label
+        hidden_label!(TestLabel);
+        let deser_label: Hidden<u8, TestLabel> = serde_json::from_str(&ser).unwrap();
+        assert_eq!(hidden.reveal(), deser_label.reveal());
+    }
+
+    #[test]
+    fn masking() {
+        let hidden = Hidden::<u8>::hide(1u8);
+        let formatted = format!("{}", hidden);
+        let expected = format!("Hidden<{}, {}>", type_name::<u8>(), type_name::<DefaultHiddenLabel>());
+        assert_eq!(formatted, expected);
     }
 }

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -46,7 +46,7 @@ use zeroize::Zeroize;
 /// The macro is a useful way to generate a hidden type that is subject to the compiler's type guarantees.
 /// This can be useful if you need multiple hidden types that use the same underlying data type, but shouldn't be
 /// confused for each other.
-/// 
+///
 /// Note that it may not be safe to dereference the hidden data if its type implements `Copy`.
 /// If the type does not implement `Copy`, you should be fine.
 /// If it does, avoid dereferencing.

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -124,15 +124,15 @@ hidden_label!(DefaultHiddenLabel);
 /// hidden_label!(KeyForCipherBLabel);
 ///
 /// // Both ciphers have keys that are `[u8; 32]` under the hood
-/// type KeyForCipherA = Hidden<[u8; 32], KeyForCipherALabel);
-/// type KeyForCipherB = Hidden<[u8; 32], KeyForCipherBLabel);
+/// type KeyForCipherA = Hidden<[u8; 32], KeyForCipherALabel>;
+/// type KeyForCipherB = Hidden<[u8; 32], KeyForCipherBLabel>;
 ///
 /// // Create a key for each cipher; notice the underlying data is the same for both
 /// let key_a = KeyForCipherA::hide([1u8; 32]);
-/// let key_b = KeyForCipherA::hide([1u8; 32]);
+/// let key_b = KeyForCipherB::hide([1u8; 32]);
 ///
 /// // The compiler won't let us treat them the same; this won't build
-/// assert_eq!(key_a.reveal(), key_b.reveal());
+/// assert_eq!(key_a, key_b);
 /// ```
 ///
 /// But if you choose not to use a label, you can mix and match hidden types. Be careful if you do this!
@@ -150,7 +150,7 @@ hidden_label!(DefaultHiddenLabel);
 /// let b = TypeB::default();
 ///
 /// // You can mix and match these! Be sure that's what you actually intended.
-/// assert_eq!(a.reveal(), b.reveal());
+/// assert_eq!(a, b);
 /// ```
 #[derive(Clone, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -37,6 +37,7 @@ use zeroize::Zeroize;
 ///
 /// ```edition2018
 /// # #[macro_use] extern crate tari_utilities;
+/// # use serde::{Deserialize, Serialize};
 /// # use tari_utilities::Hidden;
 /// # use zeroize::Zeroize;
 /// # fn main() {
@@ -49,7 +50,8 @@ use zeroize::Zeroize;
 macro_rules! hidden_type {
     ($name:ident, $type:ty) => {
         /// A hidden type
-        #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Zeroize)]
+        #[derive(Clone, Debug, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize, Zeroize)]
+        #[serde(transparent)]
         pub struct $name
         where
             $type: Default + Zeroize,

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -26,154 +26,100 @@
 //! differentiation to avoid it being misused in an unintended context. This library provides a generic type that can
 //! help.
 
-use std::{any::type_name, fmt, marker::PhantomData};
+use std::{any::type_name, fmt};
 
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
-/// A marker trait for labeling different hidden types
-pub trait HiddenLabel {}
-
-/// This is a macro that produces a label for a hidden type.
+/// This is a macro that produces a hidden type.
 /// You can use it to generate multiple hidden types that can't be unintentionally mixed up in things like function
-/// definitions. You shouldn't ever need to access it directly once you define your hidden type, since it only exists to
-/// keep types in order.
-///
-/// Its use is optional; as shown elsewhere in this documentation, you can define a hidden type without the use of a
-/// label, in which a default one will be applied for you. But if you do that, you don't get the type enforcement
-/// benefits.
+/// definitions.
 ///
 /// ```edition2018
 /// # #[macro_use] extern crate tari_utilities;
-/// # use tari_utilities::hidden::HiddenLabel;
-/// # use tari_utilities::hidden_label;
+/// # use tari_utilities::Hidden;
+/// # use zeroize::Zeroize;
 /// # fn main() {
-/// // This makes `MyHiddenTypeLabel` available for later use when defining a hidden type
-/// hidden_label!(MyHiddenTypeLabel);
+/// hidden_type!(MyHiddenType, [u8; 32]);
+/// let example = MyHiddenType::default();
+/// assert_eq!(example.reveal(), &[0u8; 32]);
 /// # }
 /// ```
 #[macro_export]
-macro_rules! hidden_label {
-    ($name:ident) => {
-        /// A hidden type label
-        #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
-        pub struct $name;
+macro_rules! hidden_type {
+    ($name:ident, $type:ty) => {
+        /// A hidden type
+        #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd, Zeroize)]
+        pub struct $name
+        where
+            $type: Default + Zeroize,
+        {
+            data: Hidden<$type>,
+        }
 
-        impl HiddenLabel for $name {}
+        impl $name {
+            /// Get an immutable reference to the data
+            #[allow(dead_code)]
+            pub fn reveal(&self) -> &$type {
+                self.data.reveal()
+            }
+
+            /// Get a mutable reference to the data
+            #[allow(dead_code)]
+            pub fn reveal_mut(&mut self) -> &mut $type {
+                self.data.reveal_mut()
+            }
+        }
     };
 }
 
-// This is the hidden type label that is used internally if you define a hidden type without proving your own label
-hidden_label!(DefaultHiddenLabel);
-
-/// A generic type for data that needs to be kept hidden, needs to be zeroized when out of scope, and is resistant to
-/// misuse.
+/// A generic type for data that needs to be kept hidden and zeroized when out of scope
 ///
 /// You can define a hidden type using any underlying type that supports `Default` and `Zeroize`.
 /// This is the case for most basic types that you probably care about.
 ///
-/// You can optionally supply a label to the hidden type, which lets you define multiple hidden types that can't be
-/// interchanged. To do this, use the `hidden_label!` macro to define a label, and then use it when defining your hidden
-/// type. If you don't include a label, a default one is used for you.
-///
 /// Hidden data can't be copied, which is an intentional design decision, and you can only access it as a reference.
 /// However, it supports other functionality transparently: cloning, equality, ordering, serialization, and the like.
-/// Note an important fact about serialization: it's transparent, so the type label isn't serialized.
-/// This means you should be sure to know the label you intend during deserialization!
 ///
 /// ```edition2018
 /// # use rand::rngs::OsRng;
 /// # use rand::RngCore;
-/// # use tari_utilities::hidden::{Hidden, HiddenLabel};
-/// # use tari_utilities::hidden_label;
+/// # use tari_utilities::hidden::Hidden;
 ///
-/// // In this example, we need to handle keys for a cipher that are `[u8; 32]` byte arrays
-///
-/// // Define a label for the new hidden type
-/// // This ensures that any other `[u8; 32]` hidden types can't get confused with this one
-/// hidden_label!(CipherKeyLabel);
-///
-/// // Alias a new hidden type using the data type and label
-/// type CipherKey = Hidden<[u8; 32], CipherKeyLabel>;
+/// // In this example, we need to handle secret data of type `[u8; 32]`.
 ///
 /// // We can create hidden data from existing data; in this case, it's the caller's responsibility to make sure the existing data is handled securely
-/// let key_from_data = CipherKey::hide([1u8; 32]);
+/// let hidden_from_data = Hidden::<[u8; 32]>::hide([1u8; 32]);
 ///
 /// // We can access the hidden data as a reference, but not take ownership of it
-/// assert_eq!(key_from_data.reveal(), &[1u8; 32]);
+/// assert_eq!(hidden_from_data.reveal(), &[1u8; 32]);
 ///
 /// // We can create default hidden data and then modify it as a mutable reference; this is common for functions that act on data in place
 /// let mut rng = OsRng;
-/// let mut key_in_place = CipherKey::default();
-/// rng.fill_bytes(key_in_place.reveal_mut());
+/// let mut hidden_in_place = Hidden::<[u8; 32]>::default();
+/// rng.fill_bytes(hidden_in_place.reveal_mut());
 ///
 /// // Cloning is safe to do
-/// let clone = key_in_place.clone();
-/// assert_eq!(key_in_place.reveal(), clone.reveal());
-/// ```
-///
-/// Type enforcement means the compiler won't let you mix and match hidden types with different labels.
-/// This can be important when dealing with different types of key material, for example.
-///
-/// ```compile_fail
-/// # use tari_utilities::hidden::{Hidden, HiddenLabel};
-/// # use tari_utilities::hidden_label;
-///
-/// // These are labels for different hidden types we want to create; in this case, keys for two different ciphers
-/// hidden_label!(KeyForCipherALabel);
-/// hidden_label!(KeyForCipherBLabel);
-///
-/// // Both ciphers have keys that are `[u8; 32]` under the hood
-/// type KeyForCipherA = Hidden<[u8; 32], KeyForCipherALabel>;
-/// type KeyForCipherB = Hidden<[u8; 32], KeyForCipherBLabel>;
-///
-/// // Create a key for each cipher; notice the underlying data is the same for both
-/// let key_a = KeyForCipherA::hide([1u8; 32]);
-/// let key_b = KeyForCipherB::hide([1u8; 32]);
-///
-/// // The compiler won't let us treat them the same; this won't build
-/// assert_eq!(key_a, key_b);
-/// ```
-///
-/// But if you choose not to use a label, you can mix and match hidden types. Be careful if you do this!
-///
-/// ```edition2018
-/// # use tari_utilities::hidden::{Hidden, HiddenLabel};
-/// # use tari_utilities::hidden_label;
-///
-/// // Define two types with no labels; you probably don't want to actually do this!
-/// type TypeA = Hidden<[u8; 32]>;
-/// type TypeB = Hidden<[u8; 32]>;
-///
-/// // Create an instance of both
-/// let a = TypeA::default();
-/// let b = TypeB::default();
-///
-/// // You can mix and match these! Be sure that's what you actually intended.
-/// assert_eq!(a, b);
+/// let clone = hidden_in_place.clone();
+/// assert_eq!(hidden_in_place.reveal(), clone.reveal());
 /// ```
 #[derive(Clone, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]
-pub struct Hidden<T, L = DefaultHiddenLabel>
+pub struct Hidden<T>
 where
     T: Zeroize,
-    L: HiddenLabel,
 {
     inner: Box<T>,
-    #[serde(skip)]
-    _type: PhantomData<L>,
 }
 
-impl<T, L> Hidden<T, L>
+impl<T> Hidden<T>
 where
     T: Zeroize,
-    L: HiddenLabel,
 {
     /// Create new hidden data from the underlying type
     pub fn hide(inner: T) -> Self {
         Self {
             inner: Box::new(inner),
-            _type: PhantomData,
         }
     }
 
@@ -189,32 +135,29 @@ where
 }
 
 /// Only output masked data for debugging, keeping the hidden data hidden
-impl<T, L> fmt::Debug for Hidden<T, L>
+impl<T> fmt::Debug for Hidden<T>
 where
     T: Zeroize,
-    L: HiddenLabel,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Hidden<{}, {}>", type_name::<T>(), type_name::<L>(),)
+        write!(f, "Hidden<{}>", type_name::<T>())
     }
 }
 
 /// Only display masked data, keeping the hidden data hidden
-impl<T, L> fmt::Display for Hidden<T, L>
+impl<T> fmt::Display for Hidden<T>
 where
     T: Zeroize,
-    L: HiddenLabel,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Hidden<{}, {}>", type_name::<T>(), type_name::<L>(),)
+        write!(f, "Hidden<{}>", type_name::<T>())
     }
 }
 
 /// Zeroize the hidden data
-impl<T, L> Zeroize for Hidden<T, L>
+impl<T> Zeroize for Hidden<T>
 where
     T: Zeroize,
-    L: HiddenLabel,
 {
     fn zeroize(&mut self) {
         self.inner.zeroize();
@@ -222,10 +165,9 @@ where
 }
 
 /// Zeroize the hidden data when dropped
-impl<T, L> Drop for Hidden<T, L>
+impl<T> Drop for Hidden<T>
 where
     T: Zeroize,
-    L: HiddenLabel,
 {
     fn drop(&mut self) {
         self.zeroize();
@@ -255,18 +197,23 @@ mod tests {
 
         let deser: Hidden<u8> = serde_json::from_str(&ser).unwrap();
         assert_eq!(hidden, deser);
-
-        // You can deserialize with any label
-        hidden_label!(TestLabel);
-        let deser_label: Hidden<u8, TestLabel> = serde_json::from_str(&ser).unwrap();
-        assert_eq!(hidden.reveal(), deser_label.reveal());
     }
 
     #[test]
     fn masking() {
         let hidden = Hidden::<u8>::hide(1u8);
         let formatted = format!("{}", hidden);
-        let expected = format!("Hidden<{}, {}>", type_name::<u8>(), type_name::<DefaultHiddenLabel>());
+        let expected = format!("Hidden<{}>", type_name::<u8>());
         assert_eq!(formatted, expected);
+    }
+
+    #[test]
+    fn types() {
+        hidden_type!(TypeA, [u8; 32]);
+        hidden_type!(TypeB, [u8; 32]);
+        let a = TypeA::default();
+        let b = TypeB::default();
+
+        assert_eq!(a.reveal(), b.reveal());
     }
 }

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -54,7 +54,7 @@ macro_rules! hidden_type {
         #[serde(transparent)]
         pub struct $name
         where
-            $type: Default + Zeroize,
+            $type: Zeroize,
         {
             data: Hidden<$type>,
         }
@@ -70,6 +70,12 @@ macro_rules! hidden_type {
             #[allow(dead_code)]
             pub fn reveal_mut(&mut self) -> &mut $type {
                 self.data.reveal_mut()
+            }
+        }
+
+        impl From<$type> for $name {
+            fn from(t: $type) -> Self {
+                Self { data: Hidden::hide(t) }
             }
         }
     };

--- a/src/hidden.rs
+++ b/src/hidden.rs
@@ -55,6 +55,7 @@ pub trait HiddenLabel {}
 #[macro_export]
 macro_rules! hidden_label {
     ($name:ident) => {
+        /// A hidden type label
         #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
         pub struct $name;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@ pub mod fixed_set;
 pub mod hash;
 pub mod hex;
 #[macro_use]
-pub mod locks;
 pub mod hidden;
+pub mod locks;
 pub mod message_format;
 pub mod password;
 pub mod serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod hidden;
 pub mod locks;
 pub mod message_format;
 pub mod password;
+pub mod safe_array;
 pub mod serde;
 
 pub use self::{

--- a/src/message_format.rs
+++ b/src/message_format.rs
@@ -71,7 +71,7 @@ where T: DeserializeOwned + Serialize
 
     fn to_base64(&self) -> Result<String, MessageFormatError> {
         let val = self.to_binary()?;
-        Ok(base64::encode(&val))
+        Ok(base64::encode(val))
     }
 
     fn from_binary(msg: &[u8]) -> Result<Self, MessageFormatError> {

--- a/src/password.rs
+++ b/src/password.rs
@@ -16,7 +16,7 @@ hidden_label!(SafePasswordLabel);
 /// It is converted to a byte array, which can be accessed as a mutable or immutable reference.
 ///
 /// ```edition2018
-/// # use tari_utilities::SafePassword
+/// # use tari_utilities::SafePassword;
 ///
 /// // Create a safe passphrase
 /// let passphrase = SafePassword::from("my secret passphrase");
@@ -24,7 +24,7 @@ hidden_label!(SafePasswordLabel);
 /// // We can also use a string directly
 /// assert_eq!(
 ///     passphrase.reveal(),
-///     SafePassword::from("my secret passphrase".to_string())
+///     SafePassword::from("my secret passphrase".to_string()).reveal()
 /// );
 /// ```
 pub type SafePassword = Hidden<Vec<u8>, SafePasswordLabel>;

--- a/src/password.rs
+++ b/src/password.rs
@@ -28,12 +28,12 @@ impl FromStr for SafePassword {
     type Err = PasswordError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::hide(s.as_bytes().to_vec()))
+        Ok(Self::hide(<&str as Into<String>>::into(s).into_bytes()))
     }
 }
 
 impl<S: Into<String>> From<S> for SafePassword {
     fn from(s: S) -> Self {
-        Self::hide(s.into().as_bytes().to_vec())
+        Self::hide(s.into().into_bytes())
     }
 }

--- a/src/password.rs
+++ b/src/password.rs
@@ -1,41 +1,25 @@
 //! A module with a safe password wrapper.
 
-use std::{error::Error, fmt, str::FromStr};
+use std::{error::Error, fmt::Display, str::FromStr};
 
-use serde::{Deserialize, Serialize};
-use zeroize::Zeroize;
+use crate::{
+    hidden::{Hidden, HiddenLabel},
+    hidden_label,
+};
 
-use crate::Hidden;
+hidden_label!(SafePasswordLabel);
 
-/// A hidden string that implements [`Zeroize`].
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(transparent)]
-pub struct SafePassword {
-    password: Hidden<Box<[u8]>>,
-}
+/// A hidden password type that zeroizes when it goes away
+pub type SafePassword = Hidden<Vec<u8>, SafePasswordLabel>;
 
-impl<S: Into<String>> From<S> for SafePassword {
-    fn from(s: S) -> Self {
-        Self {
-            password: Hidden::from(s.into().into_bytes().into_boxed_slice()),
-        }
-    }
-}
-
-impl Drop for SafePassword {
-    fn drop(&mut self) {
-        self.password.reveal_mut().zeroize();
-    }
-}
-
-/// An error for parsing a password from string.
+/// An error for parsing a password from a string
 #[derive(Debug)]
 pub struct PasswordError;
 
 impl Error for PasswordError {}
 
-impl fmt::Display for PasswordError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for PasswordError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "PasswordError")
     }
 }
@@ -44,26 +28,12 @@ impl FromStr for SafePassword {
     type Err = PasswordError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self::from(s.to_owned()))
+        Ok(Self::hide(s.as_bytes().to_vec()))
     }
 }
 
-impl SafePassword {
-    /// Gets a reference to bytes of a passphrase.
-    pub fn reveal(&self) -> &[u8] {
-        self.password.reveal()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::SafePassword;
-
-    #[test]
-    fn test_password() {
-        assert_eq!(
-            SafePassword::from("secret_must_match".to_string()),
-            SafePassword::from("secret_must_match")
-        );
+impl<S: Into<String>> From<S> for SafePassword {
+    fn from(s: S) -> Self {
+        Self::hide(s.into().as_bytes().to_vec())
     }
 }

--- a/src/password.rs
+++ b/src/password.rs
@@ -4,7 +4,6 @@ use std::{error::Error, fmt::Display, str::FromStr};
 
 use crate::hidden::Hidden;
 use serde::{Deserialize, Serialize};
-use zeroize::Zeroize;
 
 /// A representation of a passphrase that zeroizes on drop, prevents display and debug output, and limits access to
 /// references
@@ -24,7 +23,7 @@ use zeroize::Zeroize;
 ///     SafePassword::from("my secret passphrase".to_string()).reveal()
 /// );
 /// ```
-#[derive(Clone, Debug, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize, Zeroize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct SafePassword {
     passphrase: Hidden<Vec<u8>>,
@@ -82,9 +81,18 @@ mod tests {
         let from_string = SafePassword::from(password.to_string());
         let from_string_ref = SafePassword::from(password);
 
-        assert_eq!(from_str, from_string);
         assert_eq!(from_str.reveal(), from_string.reveal());
-        assert_eq!(from_string, from_string_ref);
         assert_eq!(from_string.reveal(), from_string_ref.reveal());
+    }
+
+    #[test]
+    fn serialize() {
+        let password = "password";
+
+        let hidden = SafePassword::from(password);
+        let ser = serde_json::to_string(&hidden).unwrap();
+
+        let deser: SafePassword = serde_json::from_str(&ser).unwrap();
+        assert_eq!(hidden.reveal(), deser.reveal());
     }
 }

--- a/src/password.rs
+++ b/src/password.rs
@@ -3,6 +3,7 @@
 use std::{error::Error, fmt::Display, str::FromStr};
 
 use crate::hidden::Hidden;
+use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
 
 /// A representation of a passphrase that zeroizes on drop, prevents display and debug output, and limits access to
@@ -23,7 +24,8 @@ use zeroize::Zeroize;
 ///     SafePassword::from("my secret passphrase".to_string()).reveal()
 /// );
 /// ```
-#[derive(Debug, Eq, PartialEq, Zeroize)]
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Zeroize)]
+#[serde(transparent)]
 pub struct SafePassword {
     passphrase: Hidden<Vec<u8>>,
 }

--- a/src/password.rs
+++ b/src/password.rs
@@ -24,7 +24,7 @@ use zeroize::Zeroize;
 ///     SafePassword::from("my secret passphrase".to_string()).reveal()
 /// );
 /// ```
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, Zeroize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize, Zeroize)]
 #[serde(transparent)]
 pub struct SafePassword {
     passphrase: Hidden<Vec<u8>>,

--- a/src/password.rs
+++ b/src/password.rs
@@ -1,4 +1,4 @@
-//! A module with a safe password wrapper.
+//! A type for handling a passphrase safely.
 
 use std::{error::Error, fmt::Display, str::FromStr};
 
@@ -9,7 +9,24 @@ use crate::{
 
 hidden_label!(SafePasswordLabel);
 
-/// A hidden password type that zeroizes when it goes away
+/// A representation of a passphrase that zeroizes on drop, prevents display and debug output, and limits access to
+/// references
+///
+/// The passphrase can be instantiated from a string or any type that can become a string.
+/// It is converted to a byte array, which can be accessed as a mutable or immutable reference.
+///
+/// ```edition2018
+/// # use tari_utilities::SafePassword
+///
+/// // Create a safe passphrase
+/// let passphrase = SafePassword::from("my secret passphrase");
+///
+/// // We can also use a string directly
+/// assert_eq!(
+///     passphrase.reveal(),
+///     SafePassword::from("my secret passphrase".to_string())
+/// );
+/// ```
 pub type SafePassword = Hidden<Vec<u8>, SafePasswordLabel>;
 
 /// An error for parsing a password from a string
@@ -35,5 +52,24 @@ impl FromStr for SafePassword {
 impl<S: Into<String>> From<S> for SafePassword {
     fn from(s: S) -> Self {
         Self::hide(s.into().into_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::SafePassword;
+
+    #[test]
+    fn from_strings() {
+        let password = "password";
+
+        let from_str = SafePassword::from_str(password).unwrap();
+        let from_string = SafePassword::from(password.to_string());
+        let from_string_ref = SafePassword::from(password);
+
+        assert_eq!(from_str, from_string);
+        assert_eq!(from_string, from_string_ref);
     }
 }

--- a/src/safe_array.rs
+++ b/src/safe_array.rs
@@ -22,42 +22,57 @@
 
 //! An array-like type with safety features that make it suitable for cryptographic keys.
 
-use std::fmt::Debug;
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
 
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
 /// Sometimes it is not good that an array be used for a cryptographic key.
-/// 
+///
 /// For example, creating `Hidden` data out of such an array may cause copies to arise if the data is dereferenced.
 /// Further, you likely want constant-time equality testing.
-/// 
+///
 /// A `SafeArray<T, const N: usize>` is a useful generic type that looks like an array where it counts for keys.
 /// It supports reference access by implementing `AsRef<[T]>` and `AsMut<[T]>`, but does not implement `Copy`.
-/// It also supports `Default` for handy instantiation, as well as `Clone`.
-/// It also automatically handles equality checking in constant time.
-/// 
+/// It also supports `Deref` and `DerefMut` with `[T]` targets.
+/// Further, you get `Default` for handy instantiation, as well as `Clone`.
+/// It automatically handles equality checking in constant time.
+///
 /// Under the hood, it's just `Vec<T>`, but don't tell anybody.
-/// 
-/// It's recommended that you use it as part of `Hidden` types when you need a cryptographic key.
-/// 
+///
+/// It's recommended that you use it as part of a `Hidden` type when you need a cryptographic key, like this:
+///
 /// ```edition2018
 /// # #[macro_use] extern crate tari_utilities;
+/// # use rand::rngs::OsRng;
+/// # use rand::RngCore;
 /// # use tari_utilities::{hidden_type, hidden::Hidden, safe_array::SafeArray};
 /// # use zeroize::Zeroize;
 /// # fn main() {
 /// // Use the hidden type macro to build a new type for a 32-byte cryptographic key
 /// hidden_type!(CipherKey, SafeArray<u8, 32>);
-/// 
+///
 /// // Create a new default key
-/// let key = CipherKey::from(SafeArray::<u8, 32>::default());
-/// 
-/// // You can access references to it just like a regular array
+/// let mut key = CipherKey::from(SafeArray::default());
+///
+/// // You can access the data as an array reference
 /// assert_eq!(key.reveal().as_ref(), &[0u8; 32]);
+///
+/// // Fill the key with random data, which requires `&mut [u8]`
+/// let mut rng = OsRng;
+/// rng.fill_bytes(key.reveal_mut());
 /// }
 /// ```
 #[derive(Clone, Debug)]
 pub struct SafeArray<T, const N: usize>(Vec<T>);
+
+impl<T, const N: usize> SafeArray<T, N> {
+    /// The fixed number of elements
+    pub const LEN: usize = N;
+}
 
 impl<T, const N: usize> AsRef<[T]> for SafeArray<T, N> {
     fn as_ref(&self) -> &[T] {
@@ -71,43 +86,64 @@ impl<T, const N: usize> AsMut<[T]> for SafeArray<T, N> {
     }
 }
 
-impl<T, const N: usize> Zeroize for SafeArray<T, N> where T: Zeroize {
+impl<T, const N: usize> Deref for SafeArray<T, N> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<T, const N: usize> DerefMut for SafeArray<T, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.deref_mut()
+    }
+}
+
+impl<T, const N: usize> Zeroize for SafeArray<T, N>
+where T: Zeroize
+{
     fn zeroize(&mut self) {
         self.0.zeroize();
     }
 }
 
-impl<T, const N: usize> Default for SafeArray<T, N> where T: Clone + Default {
+impl<T, const N: usize> Default for SafeArray<T, N>
+where T: Clone + Default
+{
     fn default() -> Self {
-        let mut v = Vec::<T>::with_capacity(N);
-        v.resize(N, T::default());
-
-        Self(v)
+        Self(vec![T::default(); N])
     }
 }
 
-impl<T, const N: usize> ConstantTimeEq for SafeArray<T, N> where T: ConstantTimeEq {
+impl<T, const N: usize> ConstantTimeEq for SafeArray<T, N>
+where T: ConstantTimeEq
+{
     fn ct_eq(&self, other: &Self) -> subtle::Choice {
         self.0.ct_eq(&other.0)
     }
 }
 
 impl<T, const N: usize> Eq for SafeArray<T, N> where T: ConstantTimeEq {}
-impl<T, const N: usize> PartialEq for SafeArray<T, N> where T: ConstantTimeEq {
+impl<T, const N: usize> PartialEq for SafeArray<T, N>
+where T: ConstantTimeEq
+{
     fn eq(&self, other: &Self) -> bool {
-        self.ct_eq(&other).unwrap_u8() == 1u8
+        self.ct_eq(other).unwrap_u8() == 1u8
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn reference() {
-        use crate::{hidden_type, hidden::Hidden, safe_array::SafeArray};
-        use rand::rngs::OsRng;
-        use rand::RngCore;
+        use rand::{rngs::OsRng, RngCore};
         use zeroize::Zeroize;
-        
+
+        use crate::{hidden::Hidden, hidden_type};
+
         hidden_type!(CipherKey, SafeArray<u8, 32>);
         let key_a = CipherKey::from(SafeArray::<u8, 32>::default());
         let key_b = CipherKey::from(SafeArray::<u8, 32>::default());
@@ -121,7 +157,14 @@ mod tests {
         // Test mutable reference access
         let mut key_c = CipherKey::from(SafeArray::<u8, 32>::default());
         let mut rng = OsRng;
-        rng.fill_bytes(key_c.reveal_mut().as_mut());
+        rng.fill_bytes(key_c.reveal_mut());
         assert_ne!(key_c.reveal().as_ref(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn len() {
+        const N: usize = 64;
+        assert_eq!(SafeArray::<u8, N>::default().len(), N);
+        assert_eq!(SafeArray::<u8, 64>::LEN, N);
     }
 }

--- a/src/safe_array.rs
+++ b/src/safe_array.rs
@@ -1,0 +1,127 @@
+// Copyright 2022. The Tari Project
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+// following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+// disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+// following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+// products derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+// USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//! An array-like type with safety features that make it suitable for cryptographic keys.
+
+use std::fmt::Debug;
+
+use subtle::ConstantTimeEq;
+use zeroize::Zeroize;
+
+/// Sometimes it is not good that an array be used for a cryptographic key.
+/// 
+/// For example, creating `Hidden` data out of such an array may cause copies to arise if the data is dereferenced.
+/// Further, you likely want constant-time equality testing.
+/// 
+/// A `SafeArray<T, const N: usize>` is a useful generic type that looks like an array where it counts for keys.
+/// It supports reference access by implementing `AsRef<[T]>` and `AsMut<[T]>`, but does not implement `Copy`.
+/// It also supports `Default` for handy instantiation, as well as `Clone`.
+/// It also automatically handles equality checking in constant time.
+/// 
+/// Under the hood, it's just `Vec<T>`, but don't tell anybody.
+/// 
+/// It's recommended that you use it as part of `Hidden` types when you need a cryptographic key.
+/// 
+/// ```edition2018
+/// # #[macro_use] extern crate tari_utilities;
+/// # use tari_utilities::{hidden_type, hidden::Hidden, safe_array::SafeArray};
+/// # use zeroize::Zeroize;
+/// # fn main() {
+/// // Use the hidden type macro to build a new type for a 32-byte cryptographic key
+/// hidden_type!(CipherKey, SafeArray<u8, 32>);
+/// 
+/// // Create a new default key
+/// let key = CipherKey::from(SafeArray::<u8, 32>::default());
+/// 
+/// // You can access references to it just like a regular array
+/// assert_eq!(key.reveal().as_ref(), &[0u8; 32]);
+/// }
+/// ```
+#[derive(Clone, Debug)]
+pub struct SafeArray<T, const N: usize>(Vec<T>);
+
+impl<T, const N: usize> AsRef<[T]> for SafeArray<T, N> {
+    fn as_ref(&self) -> &[T] {
+        &self.0
+    }
+}
+
+impl<T, const N: usize> AsMut<[T]> for SafeArray<T, N> {
+    fn as_mut(&mut self) -> &mut [T] {
+        &mut self.0
+    }
+}
+
+impl<T, const N: usize> Zeroize for SafeArray<T, N> where T: Zeroize {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl<T, const N: usize> Default for SafeArray<T, N> where T: Clone + Default {
+    fn default() -> Self {
+        let mut v = Vec::<T>::with_capacity(N);
+        v.resize(N, T::default());
+
+        Self(v)
+    }
+}
+
+impl<T, const N: usize> ConstantTimeEq for SafeArray<T, N> where T: ConstantTimeEq {
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        self.0.ct_eq(&other.0)
+    }
+}
+
+impl<T, const N: usize> Eq for SafeArray<T, N> where T: ConstantTimeEq {}
+impl<T, const N: usize> PartialEq for SafeArray<T, N> where T: ConstantTimeEq {
+    fn eq(&self, other: &Self) -> bool {
+        self.ct_eq(&other).unwrap_u8() == 1u8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn reference() {
+        use crate::{hidden_type, hidden::Hidden, safe_array::SafeArray};
+        use rand::rngs::OsRng;
+        use rand::RngCore;
+        use zeroize::Zeroize;
+        
+        hidden_type!(CipherKey, SafeArray<u8, 32>);
+        let key_a = CipherKey::from(SafeArray::<u8, 32>::default());
+        let key_b = CipherKey::from(SafeArray::<u8, 32>::default());
+
+        // Test equality in constant time between the `SafeArray` types
+        assert_eq!(key_a.reveal(), key_b.reveal());
+
+        // Test equality (not in constant time) using an array reference
+        assert_eq!(key_a.reveal().as_ref(), &[0u8; 32]);
+
+        // Test mutable reference access
+        let mut key_c = CipherKey::from(SafeArray::<u8, 32>::default());
+        let mut rng = OsRng;
+        rng.fill_bytes(key_c.reveal_mut().as_mut());
+        assert_ne!(key_c.reveal().as_ref(), &[0u8; 32]);
+    }
+}


### PR DESCRIPTION
Some data, like cryptographic key material or passwords, needs special handling. Such data typically should:
- be zeroized when it goes out of scope
- never be displayed or written to debug logs
- not typically be accessed except by (mutable) reference
- have a strictly enforced type to avoid misuse

This PR updates the `Hidden` type to handle this kind of data in a generic way. Hidden types can be instantiated using any underlying type that implements `Zeroize` and an optional differentiated type created by a macro that enforces context and prevents misuse.

The hidden data is stored on the heap in a `Box` wrapper. This allows us to safely zeroize it on drop, and automatically prevents display and debug from revealing it unintentionally. Further, we only expose access to the data via immutable and mutable reference. The implementation supports `Clone` for cases where we need it, but does not support `Copy`.

We also update `SafePassword` to be an instantiation of the updated `Hidden` type. This refactor is transparent to callers, as its existing API is unchanged.