### PR TITLE
fix: bump borsh version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 base58-monero = { version = "0.3.2", default-features = false }
 base64 = "0.13.0"
 bincode = "1.3.3"
-borsh = { version = "0.9.3", optional = true }
+borsh = { version = "0.10.3", optional = true }
 generic-array = "0.14.6"
 newtype-ops = "0.1.4"
 serde = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
As in the title. Bump the borsh for RUSTSEC-2023-0033