### PR TITLE
chore: revert bump borsh version for rustsec-2023-0033 (#55)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 base58-monero = { version = "0.3.2", default-features = false }
 base64 = "0.13.0"
 bincode = "1.3.3"
-borsh = { version = "0.10.3", optional = true }
+borsh = { version = "0.9.3", optional = true }
 generic-array = "0.14.6"
 newtype-ops = "0.1.4"
 serde = { version = "1.0.0", features = ["derive"] }


### PR DESCRIPTION
This reverts commit c189a00146ceecafee880ebf1336d5e157fd4c63.

This is because we've decided not to go through the process of updating core, and tari-crypto with changes to the borsh interface. The version bump didn't actually fix the rustsec issue, which we handled differently in the core repo. This bump can be reverted until we decide to commit to the interface changes.