### PR TITLE
chore!: rename `from_bytes` to `from_canonical_bytes`

### DIFF
--- a/src/byte_array.rs
+++ b/src/byte_array.rs
@@ -57,13 +57,13 @@ pub trait ByteArray: Sized {
     /// Any failures (incorrect string length, etc) return an [ByteArrayError](enum.ByteArrayError.html) with an
     /// explanatory note.
     fn from_vec(v: &Vec<u8>) -> Result<Self, ByteArrayError> {
-        Self::from_bytes(v.as_slice())
+        Self::from_canonical_bytes(v.as_slice())
     }
 
     /// Try and convert the given byte array to the implemented type. Any failures (incorrect array length,
     /// implementation-specific checks, etc.) return a [ByteArrayError](enum.ByteArrayError.html) with an explanatory
     /// note.
-    fn from_bytes(bytes: &[u8]) -> Result<Self, ByteArrayError>;
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, ByteArrayError>;
 
     /// Return the type as a byte array.
     fn as_bytes(&self) -> &[u8];
@@ -78,7 +78,7 @@ impl ByteArray for Vec<u8> {
         Ok(v.clone())
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, ByteArrayError> {
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, ByteArrayError> {
         Ok(bytes.to_vec())
     }
 
@@ -88,7 +88,7 @@ impl ByteArray for Vec<u8> {
 }
 
 impl<const I: usize> ByteArray for [u8; I] {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, ByteArrayError> {
+    fn from_canonical_bytes(bytes: &[u8]) -> Result<Self, ByteArrayError> {
         if bytes.len() != I {
             return Err(ByteArrayError::IncorrectLength {});
         }
@@ -105,7 +105,7 @@ impl<const I: usize> ByteArray for [u8; I] {
 impl<T: ByteArray> Hex for T {
     fn from_hex(hex: &str) -> Result<Self, HexError> {
         let v = from_hex(hex)?;
-        Self::from_bytes(&v).map_err(|_| HexError::HexConversionError {})
+        Self::from_canonical_bytes(&v).map_err(|_| HexError::HexConversionError {})
     }
 
     fn to_hex(&self) -> String {
@@ -156,7 +156,7 @@ mod test {
 
     #[test]
     fn test_error_handling() {
-        let err = <[u8; 32]>::from_bytes(&[1, 2, 3, 4]).unwrap_err();
+        let err = <[u8; 32]>::from_canonical_bytes(&[1, 2, 3, 4]).unwrap_err();
         assert_eq!(err, ByteArrayError::IncorrectLength {});
 
         let err = <[u8; 32]>::from_hex("abcd").unwrap_err();

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -52,7 +52,7 @@ impl<T: ByteArray> Base58 for T {
     fn from_base58(data: &str) -> Result<Self, Base58Error>
     where Self: Sized {
         let bytes = base58_monero::decode(data).map_err(|e| Base58Error::DecodeError { reason: e.to_string() })?;
-        Self::from_bytes(&bytes).map_err(|e| Base58Error::ByteArrayError { reason: e.to_string() })
+        Self::from_canonical_bytes(&bytes).map_err(|e| Base58Error::ByteArrayError { reason: e.to_string() })
     }
 
     fn to_base58(&self) -> String {

--- a/src/serde/hex.rs
+++ b/src/serde/hex.rs
@@ -98,7 +98,7 @@ where T: ByteArray
 
     fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
     where E: Error {
-        T::from_bytes(v).map_err(|e| E::custom(e.to_string()))
+        T::from_canonical_bytes(v).map_err(|e| E::custom(e.to_string()))
     }
 
     fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>


### PR DESCRIPTION
Modifies the `ByteArray` trait by renaming `from_bytes` to `from_bytes_canonical` for clarity.

BREAKING CHANGE: Changes the `ByteArray` trait.