### PR TITLE
chore: remove expect from to_hex

### DIFF
--- a/src/fixed_set.rs
+++ b/src/fixed_set.rs
@@ -91,6 +91,7 @@ impl<T: Clone + PartialEq + Default> FixedSet<T> {
         }
         let mut iter = self.items.iter().filter_map(Option::as_ref);
         // Take the first item
+        // unwrap wont fail as we know there is a first item.
         let mut sum = iter.next().unwrap().clone();
         for v in iter {
             sum = &sum + v;

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -23,7 +23,7 @@
 //! Functions for conversion between binary and hex string.
 
 use alloc::{string::String, vec::Vec};
-use core::fmt::{LowerHex, Write};
+use core::fmt::LowerHex;
 
 #[cfg(feature = "serde")]
 use serde::Serializer;
@@ -31,10 +31,12 @@ use snafu::prelude::*;
 
 use crate::alloc::string::ToString;
 
+/// Maximum bytes allowed for parsing to hex.
+const MAX_BYTES_SIZE: usize = 4096;
+
 /// Any object implementing this trait has the ability to represent itself as a hexadecimal string and convert from it.
 
 /// The max len of the hex
-const MAX_BYTES_SIZE: usize = 4096;
 pub trait Hex {
     /// Try to convert the given hexadecimal string to the type.
     ///

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -68,10 +68,8 @@ where T: LowerHex {
     }
     let mut s = String::with_capacity(bytes.len() * 2);
     for byte in bytes {
-        match write!(&mut s, "{:02x}", byte) {
-            Ok(_) => {},
-            Err(_) => return "**Bytes failed to convert**".to_string(),
-        }
+        let byte_string = format!("{:02x}", byte);
+        s.push_str(&byte_string);
     }
     s
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -160,6 +160,19 @@ mod test {
     }
 
     #[test]
+    fn max_length_error() {
+        let bytes = [0; 4096];
+        let mut hex = "".to_string();
+        for _ in 0..4096 {
+            hex.push_str("00");
+        }
+        assert_eq!(hex, bytes.to_hex());
+
+        let bytes = [0; 4097];
+        assert_eq!("**String to large**", bytes.to_hex());
+    }
+
+    #[test]
     fn character_error() {
         let result = from_hex("1234567890ABCDEFG1");
         assert!(result.is_err());

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -29,7 +29,12 @@ use core::fmt::{LowerHex, Write};
 use serde::Serializer;
 use snafu::prelude::*;
 
+use crate::alloc::string::ToString;
+
 /// Any object implementing this trait has the ability to represent itself as a hexadecimal string and convert from it.
+
+/// The max len of the hex
+const MAX_BYTES_SIZE: usize = 4096;
 pub trait Hex {
     /// Try to convert the given hexadecimal string to the type.
     ///
@@ -55,12 +60,18 @@ pub enum HexError {
     HexConversionError {},
 }
 
-/// Encode the provided bytes into a hex string.
+/// Encode the provided bytes into a hex string. This will function will not fail, but will print out if it fails
 pub fn to_hex<T>(bytes: &[T]) -> String
 where T: LowerHex {
+    if bytes.len() > MAX_BYTES_SIZE {
+        return "**String to large**".to_string();
+    }
     let mut s = String::with_capacity(bytes.len() * 2);
     for byte in bytes {
-        write!(&mut s, "{:02x}", byte).expect("Unable to write");
+        match write!(&mut s, "{:02x}", byte) {
+            Ok(_) => {},
+            Err(_) => return "**Bytes failed to convert**".to_string(),
+        }
     }
     s
 }


### PR DESCRIPTION
Removes an expect from to_hex
Adds a max len to to_hex. 