### PR TITLE
feat!: change Monero encoding trait name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### ⚠ BREAKING CHANGES
 
-* Changes the `ByteArray` trait.
+* Renames Base58 trait to MBase58 trait to avoid confusion with actual base58 encoding
 
 ### Features
 
-* Changes the `ByteArray` trait.
+* Upgrade borsh to 1.5.0
+* Renames Base58 trait to MBase58 trait to avoid confusion with actual base58 encoding
 
 ### [0.7.0](https://github.com/tari-project/tari_utilities/compare/v0.6.1...v0.7.0) (2023-12-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## [0.8.0](https://github.com/tari-project/tari_utilities/compare/v0.7...v0.8.0) (2024-10-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* Changes the `ByteArray` trait.
+
+### Features
+
+* Changes the `ByteArray` trait.
+
 ### [0.7.0](https://github.com/tari-project/tari_utilities/compare/v0.6.1...v0.7.0) (2023-12-06)
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ repository = "https://github.com/tari-project/tari"
 homepage = "https://tari.com"
 readme = "README.md"
 license = "BSD-3-Clause"
-version = "0.7.0"
-edition = "2018"
+version = "0.8.0"
+edition = "2021"
 
 [dependencies]
-base58-monero = { version = "0.3", default-features = false, optional = true }
+base58-monero = { version = "2.0", default-features = false,optional = true}
 base64 = { version = "0.13", default-features = false, optional = true, features = ["alloc"] }
 bincode =  { version = "1.3", default-features = false, optional = true }
 newtype-ops = { version = "0.1", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ base58-monero = { version = "2.0", default-features = false,optional = true}
 base64 = { version = "0.13", default-features = false, optional = true, features = ["alloc"] }
 bincode =  { version = "1.3", default-features = false, optional = true }
 newtype-ops = { version = "0.1", default-features = false, optional = true }
-borsh = { version = "1.2", optional = true, features = ["derive"] }
+borsh = { version = "1.5", optional = true, features = ["derive"] }
 generic-array = { version = "0.14", default-features = false }
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, optional = true, features = ["std"] }
@@ -24,7 +24,7 @@ subtle = { version = "2.4", default-features = false }
 
 [dev-dependencies]
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
-clap = { version = "3.2", default-features = false, features = ["derive", "env", "std"] }
+clap = { version = "4.5", default-features = false, features = ["derive", "env", "std"] }
 
 [features]
 default = ["serialize", "std"]

--- a/deny.toml
+++ b/deny.toml
@@ -17,15 +17,6 @@
 # this list would mean the nix crate, as well as any of its exclusive
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
-targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #{ triple = "x86_64-unknown-linux-musl" },
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
-]
 
 # This section is considered when running `cargo deny check advisories`
 # More documentation for the advisories section can be found here:
@@ -36,15 +27,10 @@ db-path = "~/.cargo/advisory-db"
 # The url(s) of the advisory databases to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
 # The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "warn"
+
 # The lint level for crates that have been yanked from their source registry
 yanked = "warn"
-# The lint level for crates with security notices. Note that as of
-# 2019-12-17 there are no security notice advisories in
-# https://github.com/rustsec/advisory-db
-notice = "warn"
+
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
@@ -64,8 +50,6 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
 # List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
@@ -83,15 +67,8 @@ allow = [
 deny = [
     #"Nokia",
 ]
-# Lint level for licenses considered copyleft
-copyleft = "warn"
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# * both - The license will be approved if it is both OSI-approved *AND* FSF
-# * either - The license will be approved if it is either OSI-approved *OR* FSF
-# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
-# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
-# * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
+
+
 # Lint level used when no other predicates are matched
 # 1. License isn't in the allow or deny lists
 # 2. License isn't copyleft
@@ -161,16 +138,7 @@ highlight = "all"
 allow = [
     #{ name = "ansi_term", version = "=0.11.0" },
 ]
-# List of crates to deny
-deny = [
-    # Each entry the name of a crate and a version range. If version is
-    # not specified, all versions will be matched.
-    #{ name = "ansi_term", version = "=0.11.0" },
-    #
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
-]
+
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
     #{ name = "ansi_term", version = "=0.11.0" },

--- a/deny.toml
+++ b/deny.toml
@@ -61,19 +61,6 @@ allow = [
     "Unicode-DFS-2016",
     "WTFPL"
 ]
-# List of explicitly disallowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-deny = [
-    #"Nokia",
-]
-
-
-# Lint level used when no other predicates are matched
-# 1. License isn't in the allow or deny lists
-# 2. License isn't copyleft
-# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -51,6 +51,6 @@ mod test {
 
     #[test]
     fn convert_all_failed() {
-        assert!(try_convert_all::<_, u32, _>(vec![std::i64::MAX, 2, 3, 4, 5]).is_err());
+        assert!(try_convert_all::<_, u32, _>(vec![i64::MAX, 2, 3, 4, 5]).is_err());
     }
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -29,6 +29,7 @@ use snafu::prelude::*;
 use crate::ByteArray;
 
 /// Trait for encoding/decoding to base58.
+#[deprecated(since = "0.8.0", note = "please use `MBase58` instead")]
 pub trait Base58 {
     /// Convert from base58 string.
     fn from_base58(hex: &str) -> Result<Self, Base58Error>
@@ -60,6 +61,40 @@ impl<T: ByteArray> Base58 for T {
     }
 }
 
+/// Trait for encoding/decoding to base58.
+pub trait MBase58 {
+    /// Convert from base58 string.
+    fn from_monero_base58(hex: &str) -> Result<Self, crate::encoding::Base58Error>
+    where Self: Sized;
+
+    /// Convert to base58 string.
+    fn to_monero_base58(&self) -> String;
+}
+
+/// Errors for trait Base58.
+#[derive(Debug, Snafu)]
+#[allow(missing_docs)]
+pub enum MBase58Error {
+    #[snafu(display("Byte array error: `{reason}'"))]
+    ByteArrayError { reason: String },
+    #[snafu(display("Decode error: `{reason}'"))]
+    DecodeError { reason: String },
+}
+
+impl<T: ByteArray> crate::encoding::MBase58 for T {
+    fn from_monero_base58(data: &str) -> Result<Self, crate::encoding::Base58Error>
+    where Self: Sized {
+        let bytes = base58_monero::decode(data)
+            .map_err(|e| crate::encoding::Base58Error::DecodeError { reason: e.to_string() })?;
+        Self::from_canonical_bytes(&bytes)
+            .map_err(|e| crate::encoding::Base58Error::ByteArrayError { reason: e.to_string() })
+    }
+
+    fn to_monero_base58(&self) -> String {
+        base58_monero::encode(self.as_bytes()).expect("base58_monero::encode is infallible")
+    }
+}
+
 #[cfg(test)]
 mod test {
     use alloc::vec::Vec;
@@ -70,22 +105,22 @@ mod test {
 
     #[test]
     fn decoding() {
-        assert_eq!(Vec::from_base58("111111").unwrap(), vec![0; 4]);
-        assert_eq!(Vec::from_base58("11115Q").unwrap(), vec![0, 0, 0, 255]);
-        assert!(Vec::from_base58("11111O").is_err());
-        assert!(Vec::from_base58("🖖🥴").is_err());
+        assert_eq!(Vec::from_monero_base58("111111").unwrap(), vec![0; 4]);
+        assert_eq!(Vec::from_monero_base58("11115Q").unwrap(), vec![0, 0, 0, 255]);
+        assert!(Vec::from_monero_base58("11111O").is_err());
+        assert!(Vec::from_monero_base58("🖖🥴").is_err());
     }
 
     #[test]
     fn encoding() {
-        assert_eq!(vec![0; 4].to_base58(), "111111");
-        assert_eq!(vec![0, 2, 250, 39].to_base58(), "111zzz");
+        assert_eq!(vec![0; 4].to_monero_base58(), "111111");
+        assert_eq!(vec![0, 2, 250, 39].to_monero_base58(), "111zzz");
     }
 
     #[test]
     fn inverse_operations() {
         let mut bytes = vec![0; 10];
         OsRng.fill_bytes(&mut bytes);
-        assert_eq!(Vec::from_base58(&bytes.to_base58()).unwrap(), bytes);
+        assert_eq!(Vec::from_monero_base58(&bytes.to_base58()).unwrap(), bytes);
     }
 }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -49,6 +49,7 @@ pub enum Base58Error {
     DecodeError { reason: String },
 }
 
+#[allow(deprecated)]
 impl<T: ByteArray> Base58 for T {
     fn from_base58(data: &str) -> Result<Self, Base58Error>
     where Self: Sized {
@@ -64,28 +65,17 @@ impl<T: ByteArray> Base58 for T {
 /// Trait for encoding/decoding to base58.
 pub trait MBase58 {
     /// Convert from base58 string.
-    fn from_monero_base58(hex: &str) -> Result<Self, crate::encoding::Base58Error>
+    fn from_monero_base58(hex: &str) -> Result<Self, Base58Error>
     where Self: Sized;
 
     /// Convert to base58 string.
     fn to_monero_base58(&self) -> String;
 }
 
-/// Errors for trait Base58.
-#[derive(Debug, Snafu)]
-#[allow(missing_docs)]
-pub enum MBase58Error {
-    #[snafu(display("Byte array error: `{reason}'"))]
-    ByteArrayError { reason: String },
-    #[snafu(display("Decode error: `{reason}'"))]
-    DecodeError { reason: String },
-}
-
 impl<T: ByteArray> crate::encoding::MBase58 for T {
-    fn from_monero_base58(data: &str) -> Result<Self, crate::encoding::Base58Error>
+    fn from_monero_base58(data: &str) -> Result<Self, Base58Error>
     where Self: Sized {
-        let bytes = base58_monero::decode(data)
-            .map_err(|e| crate::encoding::Base58Error::DecodeError { reason: e.to_string() })?;
+        let bytes = base58_monero::decode(data).map_err(|e| Base58Error::DecodeError { reason: e.to_string() })?;
         Self::from_canonical_bytes(&bytes)
             .map_err(|e| crate::encoding::Base58Error::ByteArrayError { reason: e.to_string() })
     }
@@ -121,6 +111,6 @@ mod test {
     fn inverse_operations() {
         let mut bytes = vec![0; 10];
         OsRng.fill_bytes(&mut bytes);
-        assert_eq!(Vec::from_monero_base58(&bytes.to_base58()).unwrap(), bytes);
+        assert_eq!(Vec::from_monero_base58(&bytes.to_monero_base58()).unwrap(), bytes);
     }
 }


### PR DESCRIPTION
Changes the Monero base58 encoding name to reflect this is not standard base58 encoding and rather Monero-specific Base58 encoding. See: https://docs.getmonero.org/cryptography/base58/

Deprecates old name.

Release new version 0.8